### PR TITLE
Some tweaks and a simple solution to the distinct keywords thing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,5 +2,8 @@ BOOST=/usr/local/include
 
 CXXFLAGS=-std=c++0x -pedantic -isystem$(BOOST) -pedantic -Wall -Wextra -Werror -O3
 
+%.o: %.cpp *.hpp
+	$(CXX) $(CXXFLAGS) -c -o $@ $<
+	
 test: test.o grammar.o
 	$(CXX) $(CXXFLAGS) -o $@ $^

--- a/grammar.cpp
+++ b/grammar.cpp
@@ -51,9 +51,9 @@ struct stream_lang_impl : qi::grammar<Iterator, qi::unused_type(), qi::blank_typ
         // This is done to allow the input file to end without a proper line
         // ending (i.e. EOL), in violation of the UNIX definition of a line.
         eol = +qi::eol || qi::eoi;
-        id = qi::lexeme[qi::char_("a-zA-Z") >> *qi::char_("a-zA-Z0-9")];
+        id     = qi::lexeme[qi::alpha >> *qi::alnum];
         number = qi::double_;
-        string = qi::lexeme['"' >> *(~qi::lit('"') | "\\\"") >> '"'];
+        string = qi::lexeme['"' >> *(~qi::lit('"') | "\\\"") > '"'];
 
         source_unit =
             -module >> *statement;
@@ -163,35 +163,19 @@ struct stream_lang_impl : qi::grammar<Iterator, qi::unused_type(), qi::blank_typ
             qualified |
             ('(' > expression > ')');
 
-        id.name("id");
-        number.name("number");
-        string.name("string");
-        source_unit.name("source_unit");
-        statement.name("statement");
-        module.name("module");
-        import.name("import");
-        function.name("function");
-        params.name("params");
-        let.name("let");
-        eol.name("eol");
-        qualified.name("qualified");
-        expression.name("expression");
-        call_expression.name("call_expression");
-        logical_or_expression.name("logical_or_expression");
-        logical_and_expression.name("logical_and_expression");
-        bit_or_expression.name("bit_or_expression");
-        bit_xor_expression.name("bit_xor_expression");
-        bit_and_expression.name("bit_and_expression");
-        equality_expression.name("equality_expression");
-        relational_expression.name("relational_expression");
-        shift_expression.name("shift_expression");
-        addition_expression.name("addition_expression");
-        multiplication_expression.name("multiplication_expression");
-        power_expression.name("power_expression");
-        range_expression.name("range_expression");
-        unary_expression.name("unary_expression");
-        subscript_expression.name("subscript_expression");
-        primary_expression.name("primary_expression");
+        BOOST_SPIRIT_DEBUG_NODES(
+            (id) (number) (string)
+
+            (source_unit) (statement) (module) (import) (function) (params) (let) (eol) (qualified)
+
+            (expression)
+            (call_expression)
+            (logical_or_expression) (logical_and_expression)
+            (bit_or_expression) (bit_xor_expression) (bit_and_expression)
+            (equality_expression) (relational_expression)
+            (shift_expression) (addition_expression) (multiplication_expression) (power_expression)
+            (range_expression) (unary_expression) (subscript_expression) (primary_expression)
+        )
     }
 };
 

--- a/grammar.cpp
+++ b/grammar.cpp
@@ -211,4 +211,8 @@ template struct stream_lang<char const*>;
 
 template struct stream_lang<wchar_t const*>;
 
+template struct stream_lang<std::string::const_iterator>;
+
+template struct stream_lang<std::wstring::const_iterator>;
+
 } // namespace stream

--- a/grammar.cpp
+++ b/grammar.cpp
@@ -2,54 +2,49 @@
 #include <string>
 
 #include <boost/spirit/include/qi.hpp>
-#include <boost/fusion/include/std_pair.hpp>
-#include <boost/lambda/lambda.hpp>
 
 #include "grammar.hpp"
-
-namespace qi = boost::spirit::qi;
 
 namespace stream {
 
 template <typename Iterator>
-struct stream_lang_impl : qi::grammar<Iterator, skipper> {
-    typedef skipper space_type;
-    // TODO Replace by template alias, once GCC supports it.
-#define RULE(type) qi::rule<Iterator, space_type, type>
-    typedef qi::rule<Iterator, space_type> rule_t;
+struct stream_lang_impl : qi::grammar<Iterator, qi::unused_type(), qi::blank_type> {
+    //
+    template <typename Attr=qi::unused_type, typename... Inherited>
+    using rule_t = qi::rule<Iterator, Attr(Inherited...), qi::blank_type>;
+    //
 
-    RULE(std::string()) id;
-    RULE(double()) number;
-    RULE(std::string()) string;
-    rule_t source_unit;
-    rule_t statement;
-    rule_t module;
-    rule_t import;
-    rule_t function;
-    rule_t params;
-    rule_t let;
-    rule_t eol;
-    rule_t qualified;
+    rule_t<std::string> id;
+    rule_t<double>      number;
+    rule_t<std::string> string;
 
-    rule_t expression;
-    rule_t call_expression;
-    rule_t logical_or_expression;
-    rule_t logical_and_expression;
-    rule_t bit_or_expression;
-    rule_t bit_xor_expression;
-    rule_t bit_and_expression;
-    rule_t equality_expression;
-    rule_t relational_expression;
-    rule_t shift_expression;
-    rule_t addition_expression;
-    rule_t multiplication_expression;
-    rule_t power_expression;
-    rule_t range_expression;
-    rule_t unary_expression;
-    rule_t subscript_expression;
-    rule_t primary_expression;
-
-#undef RULE
+    rule_t<>            source_unit;
+    rule_t<>            statement;
+    rule_t<>            module;
+    rule_t<>            import;
+    rule_t<>            function;
+    rule_t<>            params;
+    rule_t<>            let;
+    rule_t<>            eol;
+    rule_t<>            qualified;
+    
+    rule_t<>            expression;
+    rule_t<>            call_expression;
+    rule_t<>            logical_or_expression;
+    rule_t<>            logical_and_expression;
+    rule_t<>            bit_or_expression;
+    rule_t<>            bit_xor_expression;
+    rule_t<>            bit_and_expression;
+    rule_t<>            equality_expression;
+    rule_t<>            relational_expression;
+    rule_t<>            shift_expression;
+    rule_t<>            addition_expression;
+    rule_t<>            multiplication_expression;
+    rule_t<>            power_expression;
+    rule_t<>            range_expression;
+    rule_t<>            unary_expression;
+    rule_t<>            subscript_expression;
+    rule_t<>            primary_expression;
 
     stream_lang_impl() : stream_lang_impl::base_type(source_unit) {
         // EOL is redefined to be either end of line or end of input.

--- a/grammar.hpp
+++ b/grammar.hpp
@@ -6,24 +6,31 @@
 
 namespace stream {
 
-namespace qi = boost::spirit::qi;
+    namespace qi = boost::spirit::qi;
 
-template <typename Iterator>
-struct stream_lang_impl;
+    template <typename Iterator>
+    struct stream_lang_impl;
 
-template <typename Iterator>
-struct stream_lang : qi::grammar<Iterator, qi::unused_type(), qi::blank_type> {
+    template <typename Iterator>
+    struct stream_lang : qi::grammar<Iterator, qi::unused_type(), qi::blank_type> {
 
-    std::unique_ptr<stream_lang_impl<Iterator>> impl;
-    qi::rule<Iterator, qi::unused_type(), qi::blank_type> start;
+        std::unique_ptr<stream_lang_impl<Iterator>> impl;
+        qi::rule<Iterator, qi::unused_type(), qi::blank_type> start;
 
-    stream_lang();
-    ~stream_lang();
-private:
-    stream_lang(stream_lang const&) = delete;
-    stream_lang& operator =(stream_lang const&) = delete;
-};
+        stream_lang();
+        ~stream_lang();
+    private:
+        stream_lang(stream_lang const&) = delete;
+        stream_lang& operator =(stream_lang const&) = delete;
+    };
 
+    template <typename It>
+        inline bool parse(It& first, It& last)
+    {
+        static const stream_lang<It> parser;
+        return qi::phrase_parse(first, last, parser, qi::blank);
+    }
+    
 } // namespace stream
 
 #endif // ndef STREAM_GRAMMAR_HPP

--- a/grammar.hpp
+++ b/grammar.hpp
@@ -6,50 +6,22 @@
 
 namespace stream {
 
-// We want a skip parser that skips whitespace but not linebreaks.
-
-struct skipper : boost::spirit::qi::primitive_parser<skipper> {
-    template <typename Context, typename Iterator>
-    struct attribute {
-        typedef boost::spirit::qi::unused_type type;
-    };
-
-    template <typename Iterator, typename Context, typename OtherSkipper, typename Attribute>
-    bool parse(Iterator& first, Iterator const& last, Context&, OtherSkipper const& skipper, Attribute&) const {
-        boost::spirit::qi::skip_over(first, last, skipper);
-
-        if (first != last and (*first == ' ' or *first == '\t')) {
-            ++first;
-            return true;
-        }
-        return false;
-    }
-
-    template <typename Context>
-    boost::spirit::qi::info what(Context&) const {
-        return boost::spirit::qi::info("whitespace");
-    }
-};
+namespace qi = boost::spirit::qi;
 
 template <typename Iterator>
 struct stream_lang_impl;
 
 template <typename Iterator>
-struct stream_lang : boost::spirit::qi::grammar<Iterator, skipper> {
-    typedef skipper space_type;
-    typedef boost::spirit::qi::rule<Iterator, space_type> rule_type;
+struct stream_lang : qi::grammar<Iterator, qi::unused_type(), qi::blank_type> {
 
     std::unique_ptr<stream_lang_impl<Iterator>> impl;
-    rule_type start;
+    qi::rule<Iterator, qi::unused_type(), qi::blank_type> start;
 
     stream_lang();
-
     ~stream_lang();
-
 private:
-
-    stream_lang(stream_lang const&);
-    stream_lang& operator =(stream_lang const&);
+    stream_lang(stream_lang const&) = delete;
+    stream_lang& operator =(stream_lang const&) = delete;
 };
 
 } // namespace stream

--- a/test.cpp
+++ b/test.cpp
@@ -6,7 +6,6 @@
 
 #include "grammar.hpp"
 
-namespace qi = boost::spirit::qi;
 using namespace stream;
 using namespace std;
 
@@ -58,7 +57,7 @@ int main() {
 
     cout << "Attempting to parse <<<HEREDOC\n" << message << "HEREDOC;\n";
     try {
-        bool r = qi::phrase_parse(first, last, parser, skipper());
+        bool r = qi::phrase_parse(first, last, parser, qi::blank);
         bool success = r and (first == last);
 
         cout << boolalpha << "r: " << r << ", success: " << success << "\n";

--- a/test.cpp
+++ b/test.cpp
@@ -32,10 +32,7 @@ void print_info(boost::spirit::info const& what) {
 }
 
 int main() {
-    typedef char const* iter_t;
-    stream_lang<iter_t> parser;
-
-    char const* message =
+    const std::string message =
         "module test\n"
         "\n"
         "import io\n"
@@ -52,16 +49,18 @@ int main() {
         "\n"
         "io.print \"Hello world\"\n"
         ;
-    char const* first = message;
-    char const* last = message + strlen(message);
+
+    auto first = message.begin(),
+         last  = message.end();
 
     cout << "Attempting to parse <<<HEREDOC\n" << message << "HEREDOC;\n";
+
     try {
-        bool r = qi::phrase_parse(first, last, parser, qi::blank);
+        bool r = stream::parse(first, last);
         bool success = r and (first == last);
 
         cout << boolalpha << "r: " << r << ", success: " << success << "\n";
-        cout << "Remaining: \"" << first << "\"\n";
+        cout << "Remaining: \"" << std::string(first,last) << "\"\n";
     }
     catch (qi::expectation_failure<char const*> const& error) {
         print_info(error.what_);


### PR DESCRIPTION
Look at the last commit only for the `kw` parser

I aimed for quick & dirty. IIRC Spirit Repository already contains a thing like this, but it's more fun to write it:

```
// a quick and dirty distinct keyword parser `kw`: Should be effective,
// at least to avoid parsing partial identifiers as keywords
static const qi::rule<Iterator, qi::unused_type(const char*)> kw = qi::lit(qi::_r1) >> !qi::alnum;
```

And use it wherever you needed it:

```
        kw(+"module") > qualified > eol;
```

Test still compiles and passes.

PS. Note how the absence of a skipper on `kw` means 'implied lexeme' semantics.
